### PR TITLE
feat: location API 추가

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,9 +20,7 @@ app.use(
   })
 );
 
-const {
-  getRecentItems,
-} = require("./src/controller/ItemController");
+const { getRecentItems } = require("./src/controller/ItemController");
 
 app.use(express.json());
 
@@ -36,6 +34,7 @@ const MyPageRouter = require("./src/routes/myPage");
 const StoreRouter = require("./src/routes/store");
 const ChatRouter = require("./src/routes/chats");
 const CategoryRouter = require("./src/routes/category");
+const LocationRouter = require("./src/routes/location");
 
 app.use("/items", itemRouter);
 app.use("/users/likes", likeRouter);
@@ -45,6 +44,7 @@ app.use("/users", MyPageRouter);
 app.use("/store", StoreRouter);
 app.use("/categories", CategoryRouter);
 app.use("/chats", ChatRouter);
+app.use("/location", LocationRouter);
 
 app.get("/", getRecentItems);
 app.get("/favicon.ico", (req, res) => res.sendStatus(204));

--- a/src/controller/ItemController.js
+++ b/src/controller/ItemController.js
@@ -109,7 +109,6 @@ const getMyItems = (req, res) => {
 };
 
 const getItemDetail = async (req, res) => {
-
   const item_id = req.params.id;
   const user_id = req.user?.user_id ?? 0;
 
@@ -134,12 +133,18 @@ const getItemDetail = async (req, res) => {
                     FALSE
                 ) AS is_seller,
             u.nickname AS user_name,
-            u.img_id AS user_image
+            u.img_id AS user_image,
+            l.title AS location_title,
+            l.coordinate_x,
+            l.coordinate_y,
+            l.address AS location_address
             FROM items i
             JOIN users u
             ON u.id = i.user_id
             LEFT JOIN categories c
             ON c.category_id = i.category_id
+            LEFT JOIN location l
+            ON i.location_id = l.id
             WHERE i.id = ?;
 `;
   let values = [user_id, user_id, item_id];
@@ -170,6 +175,12 @@ const getItemDetail = async (req, res) => {
           seller: row.user_name,
           image: row.user_image,
         },
+        location: {
+          title: row.location_title,
+          coordinate_x: row.coordinate_x,
+          coordinate_y: row.coordinate_y,
+          address: row.location_address,
+        },
       };
       return res.status(StatusCodes.OK).json(item_init);
     } else {
@@ -179,12 +190,12 @@ const getItemDetail = async (req, res) => {
 };
 
 const postItem = (req, res) => {
-  const { img_id, title, category, price, contents } = req.body;
+  const { img_id, location_id, title, category, price, contents } = req.body;
   const user_id = req.user.user_id;
 
   let sql =
-    "INSERT INTO items (img_id, category_id, user_id, title, price, contents) VALUES(?, ?, ?, ?, ?, ?)";
-  let values = [img_id, category, user_id, title, price, contents];
+    "INSERT INTO items (img_id, category_id, user_id, location_id, title, price, contents) VALUES(?, ?, ?, ?, ?, ?, ?)";
+  let values = [img_id, category, user_id, location_id, title, price, contents];
   db.query(sql, values, (err, results) => {
     if (err) {
       console.log(err);
@@ -226,29 +237,59 @@ const updateItem = (req, res) => {
   });
 };
 
-const deleteItem = (req, res) => {
-  const item_id = req.params.id;
-  let sql = "DELETE FROM items WHERE id = ?";
-  let values = [item_id];
-
-  db.query(sql, values, (err, results) => {
-    if (err) {
-      console.log(err);
-      return res
-        .status(StatusCodes.BAD_REQUEST)
-        .json({ message: "상품 삭제에 실패했습니다." });
-    }
-
-    if (results.affectedRows > 0) {
-      return res
-        .status(StatusCodes.OK)
-        .json({ message: "상품 삭제에 성공했습니다." });
-    } else {
-      return res
-        .status(StatusCodes.BAD_REQUEST)
-        .json({ message: "상품 삭제에 실패했습니다." });
-    }
+const deleteItem = async (req, res) => {
+  const conn = await mariadb.createConnection({
+    host: process.env.DB_HOST,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+    dateStrings: true,
   });
+
+  const itemId = req.params.id;
+  let values = [itemId];
+
+  try {
+    // 1. location Id 조회
+    let sql = "SELECT location_id FROM items WHERE id = ?";
+    const [rows, fields] = await conn.query(sql, itemId);
+
+    if (!rows.length) {
+      throw new Error("location ID 조회에 실패했습니다.");
+    }
+
+    // 2. item 데이터 삭제
+    sql = "DELETE FROM items WHERE id = ?";
+
+    const [results, resultFields] = await conn.query(sql, values);
+
+    if (results.affectedRows == 0) {
+      throw new Error("item delete: affactedRows가 0입니다.");
+    }
+
+    // 3. location 데이터 삭제
+    sql = "DELETE FROM location WHERE id = ?";
+    const locationId = rows[0].location_id;
+
+    const [locationResult, locationResultFields] = await conn.query(
+      sql,
+      locationId
+    );
+
+    if (locationResult.affectedRows == 0) {
+      throw new Error("location delete: affactedRows가 0입니다.");
+    }
+
+    return res
+      .status(StatusCodes.OK)
+      .json({ message: "상품 삭제에 성공했습니다." });
+  } catch (err) {
+    return res
+      .status(StatusCodes.BAD_REQUEST)
+      .json({ message: "상품 삭제에 실패했습니다.", err });
+  } finally {
+    if (conn) await conn.end();
+  }
 };
 
 module.exports = {

--- a/src/controller/ItemController.js
+++ b/src/controller/ItemController.js
@@ -265,7 +265,7 @@ const deleteItem = async (req, res) => {
 
     const [results, resultFields] = await conn.query(sql, values);
 
-    if (results.affectedRows > 0) {
+    if (results.affectedRows < 0) {
       throw new Error("item delete: affactedRows가 0입니다.");
     }
 
@@ -278,7 +278,7 @@ const deleteItem = async (req, res) => {
       locationId
     );
 
-    if (locationResult.affectedRows > 0) {
+    if (locationResult.affectedRows < 0) {
       throw new Error("location delete: affactedRows가 0입니다.");
     }
 

--- a/src/controller/ItemController.js
+++ b/src/controller/ItemController.js
@@ -265,7 +265,7 @@ const deleteItem = async (req, res) => {
 
     const [results, resultFields] = await conn.query(sql, values);
 
-    if (results.affectedRows < 0) {
+    if (results.affectedRows === 0) {
       throw new Error("item delete: affactedRows가 0입니다.");
     }
 

--- a/src/controller/ItemController.js
+++ b/src/controller/ItemController.js
@@ -1,5 +1,6 @@
 const { StatusCodes } = require("http-status-codes");
 const db = require("../mariadb.js");
+const mariadb = require("mysql2/promise");
 const ensureAuthorization = require("../modules/auth/ensureAuthorization.js");
 
 const getCategory = (req, res) => {
@@ -107,7 +108,8 @@ const getMyItems = (req, res) => {
   });
 };
 
-const getItemDetail = (req, res) => {
+const getItemDetail = async (req, res) => {
+
   const item_id = req.params.id;
   const user_id = req.user?.user_id ?? 0;
 

--- a/src/controller/LocationController.ts
+++ b/src/controller/LocationController.ts
@@ -1,0 +1,118 @@
+import { Request, Response } from "express";
+import { Item } from "../types/ItemType";
+import { FieldPacket, OkPacket, OkPacketParams, ResultSetHeader } from "mysql2";
+import { StatusCodes } from "http-status-codes";
+import { Location } from "../types/LocationType";
+import { TokenPayload } from "../types/TokenType";
+import { User } from "../types/UserType";
+const ensureAuthorization = require("../modules/auth/ensureAuthorization");
+const jwtErrorHandler = require("../modules/auth/jwtErrorHandler");
+const mariadb = require("mysql2/promise");
+
+export const getLocation = async (req: Request, res: Response) => {
+  const conn = await mariadb.createConnection({
+    host: process.env.DB_HOST,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+    dateStrings: true,
+  });
+
+  const itemId: number = parseInt(req.params.id);
+  if (!itemId) {
+    return res
+      .status(StatusCodes.BAD_REQUEST)
+      .json({ message: "요청한 ID가 없습니다." });
+  }
+
+  let sql = "SELECT id FROM items WHERE id = ?";
+
+  try {
+    const [foundItem, foundItemFields]: [Item[], FieldPacket[]] = conn.query(
+      sql,
+      itemId
+    );
+
+    if (!foundItem?.length) {
+      return res
+        .status(StatusCodes.NOT_FOUND)
+        .json({ message: "해당 ID의 아이템을 찾을 수 없습니다." });
+    }
+
+    sql = "SELECT * FROM location WHERE item_id = ?";
+
+    const [result, resultFields]: [Location[], FieldPacket] = conn.query(
+      sql,
+      itemId
+    );
+
+    if (!result?.length) {
+      res
+        .status(StatusCodes.NOT_FOUND)
+        .json({ message: "location 정보를 불러올 수 없습니다." });
+    }
+
+    return res.status(StatusCodes.OK).json(result);
+  } catch (err) {
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      message: "location 데이터를 가져오는 동안 오류가 발생했습니다.",
+    });
+  } finally {
+    if (conn) await conn.end();
+  }
+};
+
+export const addLocation = async (req: Request, res: Response) => {
+  const conn = await mariadb.createConnection({
+    host: process.env.DB_HOST,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+    dateStrings: true,
+  });
+
+  const authorization: TokenPayload | Error = ensureAuthorization(req, res);
+
+  if (authorization instanceof ReferenceError) {
+    return res.status(StatusCodes.BAD_REQUEST).send("로그인이 필요합니다.");
+  }
+  if (authorization instanceof Error) {
+    return jwtErrorHandler(authorization, res);
+  }
+
+  const userId: number = authorization.user_id;
+  let sql = "SELECT id FROM users WHERE id = ?";
+
+  try{
+    const [foundUser, foundUserFields]: [User[], FieldPacket[]] = await conn.query(sql, userId);
+
+    if (!foundUser?.length) {
+      return res
+        .status(StatusCodes.NOT_FOUND)
+        .json({ message: "해당 ID의 사용자를 찾을 수 없습니다." });
+    }
+
+    const { item_id, title, coordinate, address } : Location = req.body;
+    const values = [ userId, item_id, title, coordinate, address ];
+    sql = "INSERT INTO location (user_id, item_id, title, coordinate, address) VALUES(?, ?, ?, ?, ?)";
+
+    const [result, resultFields]: [ResultSetHeader, FieldPacket[]] = await conn.query(sql, values);
+
+    if (result.affectedRows == 0){
+      throw new Error("데이터 삽입 실패: affectedRows가 0입니다.");
+    }
+
+    return res.status(StatusCodes.OK).json(result);
+
+  } catch (err) {
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      message: "location 데이터를 저장하는 동안 오류가 발생했습니다.",
+    });
+  } finally {
+    if (conn) await conn.end();
+  }
+}
+
+export const updateLocation = async (req: Request, res: Response) => {
+
+}

--- a/src/controller/LocationController.ts
+++ b/src/controller/LocationController.ts
@@ -88,7 +88,7 @@ export const updateLocation = async (req: Request, res: Response) => {
   }
 
   const userId: number = authorization.user_id;
-  let sql = "SELECT 1 FROM location WHERE user_id = ?";
+  let sql = "SELECT * FROM location WHERE user_id = ?";
 
   try {
     const [foundUserLocation, foundUserFields]: [Location[], FieldPacket[]] =
@@ -107,15 +107,15 @@ export const updateLocation = async (req: Request, res: Response) => {
       getNewValueOrDefault(newLocationDatas.title, foundUserLocation[0].title),
       getNewValueOrDefault(
         newLocationDatas.coordinate_x,
-        foundUserLocation[0].title
+        foundUserLocation[0].coordinate_x
       ),
       getNewValueOrDefault(
         newLocationDatas.coordinate_y,
-        foundUserLocation[0].title
+        foundUserLocation[0].coordinate_y
       ),
       getNewValueOrDefault(
         newLocationDatas.address,
-        foundUserLocation[0].title
+        foundUserLocation[0].address
       ),
       locationId
     ];
@@ -130,11 +130,10 @@ export const updateLocation = async (req: Request, res: Response) => {
       throw new Error("데이터 삽입 실패: affectedRows가 0입니다.");
     }
 
-    return res.status(StatusCodes.OK).json(result);
+    return res.status(StatusCodes.CREATED).json(result);
   } catch (err) {
     return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-      message: "location 데이터를 업데이트 하는 동안 오류가 발생했습니다.",
-      err
+      message: "location 데이터를 업데이트 하는 동안 오류가 발생했습니다."
     });
   } finally {
     if (conn) await conn.end();

--- a/src/controller/LocationController.ts
+++ b/src/controller/LocationController.ts
@@ -4,7 +4,7 @@ import { StatusCodes } from "http-status-codes";
 import { Location } from "../types/LocationType";
 import { TokenPayload } from "../types/TokenType";
 import { User } from "../types/UserType";
-import { GetNewValueOrDefault } from "./MyPageController";
+import { getNewValueOrDefault } from "./MyPageController";
 const ensureAuthorization = require("../modules/auth/ensureAuthorization");
 const jwtErrorHandler = require("../modules/auth/jwtErrorHandler");
 const mariadb = require("mysql2/promise");
@@ -104,16 +104,16 @@ export const updateLocation = async (req: Request, res: Response) => {
     const locationId: number = req.body.location_id;
 
     const values = [
-      GetNewValueOrDefault(newLocationDatas.title, foundUserLocation[0].title),
-      GetNewValueOrDefault(
+      getNewValueOrDefault(newLocationDatas.title, foundUserLocation[0].title),
+      getNewValueOrDefault(
         newLocationDatas.coordinate_x,
         foundUserLocation[0].title
       ),
-      GetNewValueOrDefault(
+      getNewValueOrDefault(
         newLocationDatas.coordinate_y,
         foundUserLocation[0].title
       ),
-      GetNewValueOrDefault(
+      getNewValueOrDefault(
         newLocationDatas.address,
         foundUserLocation[0].title
       ),

--- a/src/controller/LocationController.ts
+++ b/src/controller/LocationController.ts
@@ -130,7 +130,7 @@ export const updateLocation = async (req: Request, res: Response) => {
       throw new Error("데이터 삽입 실패: affectedRows가 0입니다.");
     }
 
-    return res.status(StatusCodes.CREATED).json(result);
+    return res.status(StatusCodes.OK).json(result);
   } catch (err) {
     return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
       message: "location 데이터를 업데이트 하는 동안 오류가 발생했습니다."

--- a/src/controller/LocationController.ts
+++ b/src/controller/LocationController.ts
@@ -1,5 +1,4 @@
 import { Request, Response } from "express";
-import { Item } from "../types/ItemType";
 import { FieldPacket, ResultSetHeader } from "mysql2";
 import { StatusCodes } from "http-status-codes";
 import { Location } from "../types/LocationType";
@@ -9,44 +8,6 @@ import { GetNewValueOrDefault } from "./MyPageController";
 const ensureAuthorization = require("../modules/auth/ensureAuthorization");
 const jwtErrorHandler = require("../modules/auth/jwtErrorHandler");
 const mariadb = require("mysql2/promise");
-
-// export const getLocation = async (req: Request, res: Response) => {
-  
-//   try {
-//     const [foundItem, foundItemFields]: [Item[], FieldPacket[]] = await conn.query(
-//       sql,
-//       itemId
-//     );
-
-//     if (!foundItem?.length) {
-//       return res
-//         .status(StatusCodes.NOT_FOUND)
-//         .json({ message: "해당 ID의 아이템을 찾을 수 없습니다." });
-//     }
-
-//     sql = "SELECT * FROM location WHERE item_id = ?";
-
-//     const [result, resultFields]: [Location[], FieldPacket] = await conn.query(
-//       sql,
-//       itemId
-//     );
-
-//     if (!result?.length) {
-//       res
-//         .status(StatusCodes.NOT_FOUND)
-//         .json({ message: "location 정보를 불러올 수 없습니다." });
-//     }
-
-//     return res.status(StatusCodes.OK).json(result);
-//   } catch (err) {
-//     console.log(err);
-//     return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-//       message: "location 데이터를 가져오는 동안 오류가 발생했습니다.",
-//     });
-//   } finally {
-//     if (conn) await conn.end();
-//   }
-// };
 
 export const addLocation = async (req: Request, res: Response) => {
   const conn = await mariadb.createConnection({
@@ -140,8 +101,7 @@ export const updateLocation = async (req: Request, res: Response) => {
     }
 
     const newLocationDatas: Location = req.body;
-
-    const locationId: number = parseInt(req.params.id);
+    const locationId: number = req.body.location_id;
 
     const values = [
       GetNewValueOrDefault(newLocationDatas.title, foundUserLocation[0].title),
@@ -160,9 +120,8 @@ export const updateLocation = async (req: Request, res: Response) => {
       locationId
     ];
 
-    // 아이템마다 location의 id를 받아와야 함! -> 어디로 받아와야 하나요!?
     sql =
-      "UPDATE location SET title = ?, coordinate = ?, address = ? WHERE id = ?";
+      "UPDATE location SET title = ?, coordinate_x = ?, coordinate_y = ?, address = ? WHERE id = ?";
 
     const [result, resultFields]: [ResultSetHeader, FieldPacket] =
       await conn.query(sql, values);
@@ -175,6 +134,7 @@ export const updateLocation = async (req: Request, res: Response) => {
   } catch (err) {
     return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
       message: "location 데이터를 업데이트 하는 동안 오류가 발생했습니다.",
+      err
     });
   } finally {
     if (conn) await conn.end();

--- a/src/controller/LocationController.ts
+++ b/src/controller/LocationController.ts
@@ -88,7 +88,7 @@ export const updateLocation = async (req: Request, res: Response) => {
   }
 
   const userId: number = authorization.user_id;
-  let sql = "SELECT * FROM location WHERE user_id = ?";
+  let sql = "SELECT 1 FROM location WHERE user_id = ?";
 
   try {
     const [foundUserLocation, foundUserFields]: [Location[], FieldPacket[]] =

--- a/src/controller/LocationController.ts
+++ b/src/controller/LocationController.ts
@@ -1,66 +1,52 @@
 import { Request, Response } from "express";
 import { Item } from "../types/ItemType";
-import { FieldPacket, OkPacket, OkPacketParams, ResultSetHeader } from "mysql2";
+import { FieldPacket, ResultSetHeader } from "mysql2";
 import { StatusCodes } from "http-status-codes";
 import { Location } from "../types/LocationType";
 import { TokenPayload } from "../types/TokenType";
 import { User } from "../types/UserType";
+import { GetNewValueOrDefault } from "./MyPageController";
 const ensureAuthorization = require("../modules/auth/ensureAuthorization");
 const jwtErrorHandler = require("../modules/auth/jwtErrorHandler");
 const mariadb = require("mysql2/promise");
 
-export const getLocation = async (req: Request, res: Response) => {
-  const conn = await mariadb.createConnection({
-    host: process.env.DB_HOST,
-    user: process.env.DB_USER,
-    password: process.env.DB_PASSWORD,
-    database: process.env.DB_NAME,
-    dateStrings: true,
-  });
+// export const getLocation = async (req: Request, res: Response) => {
+  
+//   try {
+//     const [foundItem, foundItemFields]: [Item[], FieldPacket[]] = await conn.query(
+//       sql,
+//       itemId
+//     );
 
-  const itemId: number = parseInt(req.params.id);
-  if (!itemId) {
-    return res
-      .status(StatusCodes.BAD_REQUEST)
-      .json({ message: "요청한 ID가 없습니다." });
-  }
+//     if (!foundItem?.length) {
+//       return res
+//         .status(StatusCodes.NOT_FOUND)
+//         .json({ message: "해당 ID의 아이템을 찾을 수 없습니다." });
+//     }
 
-  let sql = "SELECT id FROM items WHERE id = ?";
+//     sql = "SELECT * FROM location WHERE item_id = ?";
 
-  try {
-    const [foundItem, foundItemFields]: [Item[], FieldPacket[]] = conn.query(
-      sql,
-      itemId
-    );
+//     const [result, resultFields]: [Location[], FieldPacket] = await conn.query(
+//       sql,
+//       itemId
+//     );
 
-    if (!foundItem?.length) {
-      return res
-        .status(StatusCodes.NOT_FOUND)
-        .json({ message: "해당 ID의 아이템을 찾을 수 없습니다." });
-    }
+//     if (!result?.length) {
+//       res
+//         .status(StatusCodes.NOT_FOUND)
+//         .json({ message: "location 정보를 불러올 수 없습니다." });
+//     }
 
-    sql = "SELECT * FROM location WHERE item_id = ?";
-
-    const [result, resultFields]: [Location[], FieldPacket] = conn.query(
-      sql,
-      itemId
-    );
-
-    if (!result?.length) {
-      res
-        .status(StatusCodes.NOT_FOUND)
-        .json({ message: "location 정보를 불러올 수 없습니다." });
-    }
-
-    return res.status(StatusCodes.OK).json(result);
-  } catch (err) {
-    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-      message: "location 데이터를 가져오는 동안 오류가 발생했습니다.",
-    });
-  } finally {
-    if (conn) await conn.end();
-  }
-};
+//     return res.status(StatusCodes.OK).json(result);
+//   } catch (err) {
+//     console.log(err);
+//     return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+//       message: "location 데이터를 가져오는 동안 오류가 발생했습니다.",
+//     });
+//   } finally {
+//     if (conn) await conn.end();
+//   }
+// };
 
 export const addLocation = async (req: Request, res: Response) => {
   const conn = await mariadb.createConnection({
@@ -83,8 +69,9 @@ export const addLocation = async (req: Request, res: Response) => {
   const userId: number = authorization.user_id;
   let sql = "SELECT id FROM users WHERE id = ?";
 
-  try{
-    const [foundUser, foundUserFields]: [User[], FieldPacket[]] = await conn.query(sql, userId);
+  try {
+    const [foundUser, foundUserFields]: [User[], FieldPacket[]] =
+      await conn.query(sql, userId);
 
     if (!foundUser?.length) {
       return res
@@ -92,18 +79,26 @@ export const addLocation = async (req: Request, res: Response) => {
         .json({ message: "해당 ID의 사용자를 찾을 수 없습니다." });
     }
 
-    const { item_id, title, coordinate, address } : Location = req.body;
-    const values = [ userId, item_id, title, coordinate, address ];
-    sql = "INSERT INTO location (user_id, item_id, title, coordinate, address) VALUES(?, ?, ?, ?, ?)";
+    const newLocationDatas: Location = req.body;
+    const values = [
+      userId,
+      newLocationDatas.title,
+      newLocationDatas.coordinate_x,
+      newLocationDatas.coordinate_y,
+      newLocationDatas.address,
+    ]; 
 
-    const [result, resultFields]: [ResultSetHeader, FieldPacket[]] = await conn.query(sql, values);
+    sql =
+      "INSERT INTO location (user_id, title, coordinate_x, coordinate_y, address) VALUES(?, ?, ?, ?, ?)";
 
-    if (result.affectedRows == 0){
+    const [result, resultFields]: [ResultSetHeader, FieldPacket[]] =
+      await conn.query(sql, values);
+
+    if (result.affectedRows == 0) {
       throw new Error("데이터 삽입 실패: affectedRows가 0입니다.");
     }
 
     return res.status(StatusCodes.OK).json(result);
-
   } catch (err) {
     return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
       message: "location 데이터를 저장하는 동안 오류가 발생했습니다.",
@@ -111,8 +106,77 @@ export const addLocation = async (req: Request, res: Response) => {
   } finally {
     if (conn) await conn.end();
   }
-}
+};
 
 export const updateLocation = async (req: Request, res: Response) => {
+  const conn = await mariadb.createConnection({
+    host: process.env.DB_HOST,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+    dateStrings: true,
+  });
 
-}
+  const authorization: TokenPayload | Error = ensureAuthorization(req, res);
+
+  if (authorization instanceof ReferenceError) {
+    return res.status(StatusCodes.BAD_REQUEST).send("로그인이 필요합니다.");
+  }
+  if (authorization instanceof Error) {
+    return jwtErrorHandler(authorization, res);
+  }
+
+  const userId: number = authorization.user_id;
+  let sql = "SELECT * FROM location WHERE user_id = ?";
+
+  try {
+    const [foundUserLocation, foundUserFields]: [Location[], FieldPacket[]] =
+      await conn.query(sql, userId);
+
+    if (!foundUserLocation?.length) {
+      return res
+        .status(StatusCodes.NOT_FOUND)
+        .json({ message: "해당 ID의 사용자를 찾을 수 없습니다." });
+    }
+
+    const newLocationDatas: Location = req.body;
+
+    const locationId: number = parseInt(req.params.id);
+
+    const values = [
+      GetNewValueOrDefault(newLocationDatas.title, foundUserLocation[0].title),
+      GetNewValueOrDefault(
+        newLocationDatas.coordinate_x,
+        foundUserLocation[0].title
+      ),
+      GetNewValueOrDefault(
+        newLocationDatas.coordinate_y,
+        foundUserLocation[0].title
+      ),
+      GetNewValueOrDefault(
+        newLocationDatas.address,
+        foundUserLocation[0].title
+      ),
+      locationId
+    ];
+
+    // 아이템마다 location의 id를 받아와야 함! -> 어디로 받아와야 하나요!?
+    sql =
+      "UPDATE location SET title = ?, coordinate = ?, address = ? WHERE id = ?";
+
+    const [result, resultFields]: [ResultSetHeader, FieldPacket] =
+      await conn.query(sql, values);
+
+    if (result.affectedRows == 0) {
+      throw new Error("데이터 삽입 실패: affectedRows가 0입니다.");
+    }
+
+    return res.status(StatusCodes.OK).json(result);
+  } catch (err) {
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      message: "location 데이터를 업데이트 하는 동안 오류가 발생했습니다.",
+    });
+  } finally {
+    if (conn) await conn.end();
+  }
+};

--- a/src/controller/MyPageController.ts
+++ b/src/controller/MyPageController.ts
@@ -83,11 +83,11 @@ export const updateMyPage = async (req: Request, res: Response) => {
   sql =
     "UPDATE users SET nickname = ?, name = ?, email = ?, info = ?, contact = ?, password = ?, salt = ? WHERE id = ?";
   const values = [
-    GetNewValueOrDefault(newUserDatas.nickname, foundUser[0].nickname),
-    GetNewValueOrDefault(newUserDatas.name, foundUser[0].name),
-    GetNewValueOrDefault(newUserDatas.email, foundUser[0].email),
-    GetNewValueOrDefault(newUserDatas.info, foundUser[0].info),
-    GetNewValueOrDefault(newUserDatas.contact, foundUser[0].contact)
+    getNewValueOrDefault(newUserDatas.nickname, foundUser[0].nickname),
+    getNewValueOrDefault(newUserDatas.name, foundUser[0].name),
+    getNewValueOrDefault(newUserDatas.email, foundUser[0].email),
+    getNewValueOrDefault(newUserDatas.info, foundUser[0].info),
+    getNewValueOrDefault(newUserDatas.contact, foundUser[0].contact)
   ];
 
   let salt, newPassword;

--- a/src/controller/MyPageController.ts
+++ b/src/controller/MyPageController.ts
@@ -83,11 +83,11 @@ export const updateMyPage = async (req: Request, res: Response) => {
   sql =
     "UPDATE users SET nickname = ?, name = ?, email = ?, info = ?, contact = ?, password = ?, salt = ? WHERE id = ?";
   const values = [
-    getNewValueOrDefault(newUserDatas.nickname, foundUser[0].nickname),
-    getNewValueOrDefault(newUserDatas.name, foundUser[0].name),
-    getNewValueOrDefault(newUserDatas.email, foundUser[0].email),
-    getNewValueOrDefault(newUserDatas.info, foundUser[0].info),
-    getNewValueOrDefault(newUserDatas.contact, foundUser[0].contact)
+    GetNewValueOrDefault(newUserDatas.nickname, foundUser[0].nickname),
+    GetNewValueOrDefault(newUserDatas.name, foundUser[0].name),
+    GetNewValueOrDefault(newUserDatas.email, foundUser[0].email),
+    GetNewValueOrDefault(newUserDatas.info, foundUser[0].info),
+    GetNewValueOrDefault(newUserDatas.contact, foundUser[0].contact)
   ];
 
   let salt, newPassword;
@@ -166,7 +166,7 @@ export const deleteUser = async (req: Request, res: Response) => {
   }
 };
 
-const getNewValueOrDefault = (
+export const GetNewValueOrDefault = (
   newValue: string | number,
   defaultValue: string | number
 ) => {

--- a/src/routes/location.ts
+++ b/src/routes/location.ts
@@ -2,13 +2,10 @@ import express from "express";
 const router = express.Router();
 
 const {
-  getLocation,
   addLocation,
   updateLocation,
 } = require("../controller/LocationController");
 
 router.route("/").post(addLocation).put(updateLocation);
-
-router.route("/:id").get(getLocation);
 
 module.exports = router;

--- a/src/routes/location.ts
+++ b/src/routes/location.ts
@@ -1,0 +1,12 @@
+import express from "express";
+const router = express.Router();
+
+const {
+  getLocation,
+  addLocation,
+  updateLocation,
+} = require("../controller/LocationController");
+
+router.route("/").get(getLocation).post(addLocation).put(updateLocation);
+
+module.exports = router;

--- a/src/routes/location.ts
+++ b/src/routes/location.ts
@@ -7,6 +7,8 @@ const {
   updateLocation,
 } = require("../controller/LocationController");
 
-router.route("/").get(getLocation).post(addLocation).put(updateLocation);
+router.route("/").post(addLocation).put(updateLocation);
+
+router.route("/:id").get(getLocation);
 
 module.exports = router;

--- a/src/types/ItemType.ts
+++ b/src/types/ItemType.ts
@@ -3,6 +3,7 @@ export interface Item {
   category_id: number;
   user_id: number;
   img_id: number;
+  location_id: number;
   title: string;
   price: number;
   contents: string;

--- a/src/types/LocationType.ts
+++ b/src/types/LocationType.ts
@@ -1,0 +1,8 @@
+export interface Location {
+  id?: number;
+  user_id?: number;
+  item_id: number;
+  title: string;
+  coordinate: string;
+  address: string;
+}

--- a/src/types/LocationType.ts
+++ b/src/types/LocationType.ts
@@ -1,8 +1,8 @@
 export interface Location {
   id?: number;
   user_id?: number;
-  item_id: number;
   title: string;
-  coordinate: string;
+  coordinate_x: string; 
+  coordinate_y: string; 
   address: string;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
 
     /* Modules */
     // "module": "Node16",                                /* Specify what module code is generated. */
-    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
 
     /* Modules */
     // "module": "Node16",                                /* Specify what module code is generated. */
-    "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -107,6 +107,6 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
-  "include": ["src/**/*", "src/mariadb.js"],
+  "include": ["src/**/*", "src/mariadb.js", "app.js"],
   "exclude": ["node_modules", "dist"],
 }


### PR DESCRIPTION
### **location API를 추가하였습니다.**

**1. location 등록**
- POST: `/location`
- req.body를 통해 title (주소 별칭), coordinate_x (x 좌표), coordinate_y (y 좌표), address (상세 주소) 데이터를 입력 받습니다.

**2. location 조회**
- GET: `/items/:item_id`
- req.params를 통해 item id를 입력 받습니다.
- {user, item, location} 형식으로 데이터를 반환합니다.

**3. location 수정**
- PUT: `/location`
- req.body를 통해 id (location id), title (주소 별칭), coordinate_x (x 좌표), coordinate_y (y 좌표), address (상세 주소) 데이터를 
입력 받습니다.

**4. location 삭제**
- DELETE: `/items/:item_id`
- req.params를 통해 item id를 입력 받습니다.
- req.body를 통해 title (주소 별칭), coordinate_x (x 좌표), coordinate_y (y 좌표), address (상세 주소) 데이터를 입력 받습니다.
- 트랜젝션을 사용하여 관리합니다.